### PR TITLE
Faster conda dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ Activate the conda environment with `conda activate cdvae`.
 
 Install this package with `pip install -e .`.
 
+### Faster conda installation
+
+We've noticed that the above command to install the dependencies from `env.yml` can take very long. A faster way to install the required packages is:
+```bash
+conda env create -f env_sub.yml
+conda activate cdvae
+conda install ipywidgets jupyterlab matplotlib pylint
+conda install -c conda-forge matminer=0.7.3 nglview pymatgen=2020.12.31
+pip install -e .
+```
+
 ### CPU-only machines
 
 ```bash

--- a/env_sub.yml
+++ b/env_sub.yml
@@ -1,0 +1,39 @@
+channels:
+- pytorch
+- conda-forge
+- defaults
+dependencies:
+- ase=3.22
+- autopep8
+- cudatoolkit=10.2
+  #- ipywidgets
+  #- jupyterlab
+  #- matminer=0.7.3
+  #- matplotlib
+  #- nglview
+- pip
+  #- pylint
+  #- pymatgen=2020.12.31
+- python=3.8.*
+- pytorch-lightning=1.3.8
+- pytorch=1.9.0
+- seaborn
+- tqdm
+- pip:
+  - -f https://pytorch-geometric.com/whl/torch-1.9.0+cu102.html
+  - torch-geometric==1.7.2
+  - higher==0.2.1
+  - hydra-core==1.1.0
+  - hydra-joblib-launcher==1.1.5
+  - p-tqdm==1.3.3
+  - pytest
+  - python-dotenv
+  - smact==2.2.1
+  - streamlit==0.79.0
+  - torch-cluster
+  - torch-scatter
+  - torch-sparse
+  - torch-spline-conv
+  - torchdiffeq==0.0.1
+  - wandb==0.10.33
+name: cdvae


### PR DESCRIPTION
Installing the `conda` environment can take very long (>1h). 

In this PR I've created `env_sub.yml`, where a couple of dependencies from `env.yml` are commented out (I did not completely delete them to make transparent what exactly was left out). The ones that are commented out are then installed directly via `conda install`. For me this takes only a couple of minutes this way.

Let me know what you think :) 