### PR TITLE
Fix bug in lattice scaler assignment of test datasets.

### DIFF
--- a/cdvae/pl_data/datamodule.py
+++ b/cdvae/pl_data/datamodule.py
@@ -94,7 +94,7 @@ class CrystDataModule(pl.LightningDataModule):
                 for dataset_cfg in self.datasets.test
             ]
             for test_dataset in self.test_datasets:
-                test_dataset.lattice_scaler = self.scaler
+                test_dataset.lattice_scaler = self.lattice_scaler
                 test_dataset.scaler = self.scaler
 
     def train_dataloader(self) -> DataLoader:


### PR DESCRIPTION
Before the fix, the `lattice_scaler` was incorrectly set with the property scaler of the dataset.